### PR TITLE
Added handling for duplicate resources being saved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ install:
 script:
   - export FLASK_APP=main.py
   - export AIRTABLE_API_KEY=""
+  - export RESOURCE_TABLE="ResourcesStaging"
   - flask test

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 8. To run the service locally run `./scripts/debug.sh` and navigate to http://localhost:5000 in your preferred browseer and follow the API documentation to call a various endpoint.
 9. To run all unit tests run `./scripts/test.sh`
 
-# Setup needed for testing SSE Points endpoints
+# Setup needed for testing SSE Point endpoints
 1. Ask the webmaster for the credentials.json, the API key for google sheets, and the development google file id
 2. Place the credentials.json in your project directory and run `export GOOGLE_APPLICATION_CREDENTIALS="$(< credentials.json)"`
 3. Run `export API_KEY="<API Key Here>"`
 4. Run `export GOOGLE_FILE_ID="<File Id Here>"`
 5. To check that the environment variables have been applied correctly run `echo $GOOGLE_APPLICATION_CREDENTIALS`, `echo $API_KEY`, and `echo $GOOGLE_FILE_ID`
 
-# Setup needed for testing SSE Resources endpoints
+# Setup needed for testing SSE Resource endpoints
 1. Ask the webmaster for the Airtable API key.
 2. Run `export AIRTABLE_API_KEY="<API Key Here>"`
 3. Run `export RESOURCE_TABLE="ResourcesStaging"`

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 # Setup
 1. You will need python installed on your development machine.
     - Check version with python --version
-2. Ask the webmaster for the credentials.json, the API key for this service, and the development google file id
-3. Clone the repository
-4. Navigate to your project directory in git bash
-5. Run `pip install virtualenv` and then `virtualenv env`
-6. Activate your virtualenv by running `./env/Scripts/activate`
-7. Install the dependencies for this project by running `./env/Scripts/pip install -r requirements.txt`
-6. Place the credentials.json in your project directory and run `export GOOGLE_APPLICATION_CREDENTIALS="$(< credentials.json)"`
-7. Run `export API_KEY="<API Key Here>"`
-8. Run `export GOOGLE_FILE_ID="<File Id Here>"`
-8. To check that the environment variables have been applied correctly run `echo $GOOGLE_APPLICATION_CREDENTIALS`, `echo $API_KEY`, and `echo $GOOGLE_FILE_ID`
-9. To run the service locally run `./scripts/debug.sh` and navigate to http://localhost:5000 in your preferred browseer and follow the API documentation to call a various endpoint.
-10. To run all unit tests run `./scripts/test.sh`
+2. Clone the repository
+3. Navigate to your project directory in git bash
+4. Run `pip install virtualenv` and then `virtualenv env`
+5. Activate your virtualenv by running `./env/Scripts/activate`
+6. Install the dependencies for this project by running `./env/Scripts/pip install -r requirements.txt`
+7. Follow the specific setup steps below depending on which endpoints you're working on.
+8. To run the service locally run `./scripts/debug.sh` and navigate to http://localhost:5000 in your preferred browseer and follow the API documentation to call a various endpoint.
+9. To run all unit tests run `./scripts/test.sh`
+
+# Setup needed for testing SSE Points endpoints
+1. Ask the webmaster for the credentials.json, the API key for google sheets, and the development google file id
+2. Place the credentials.json in your project directory and run `export GOOGLE_APPLICATION_CREDENTIALS="$(< credentials.json)"`
+3. Run `export API_KEY="<API Key Here>"`
+4. Run `export GOOGLE_FILE_ID="<File Id Here>"`
+5. To check that the environment variables have been applied correctly run `echo $GOOGLE_APPLICATION_CREDENTIALS`, `echo $API_KEY`, and `echo $GOOGLE_FILE_ID`
+
+# Setup needed for testing SSE Resources endpoints
+1. Ask the webmaster for the Airtable API key.
+2. Run `export AIRTABLE_API_KEY="<API Key Here>"`
+3. Run `export RESOURCE_TABLE="ResourcesStaging"`

--- a/app/main/controllers/resources_controller.py
+++ b/app/main/controllers/resources_controller.py
@@ -16,4 +16,4 @@ class Resources(Resource):
     @api.doc('creates a new SSE resource')
     @api.expect(_resource)
     def post(self):
-        return create_resource(api.payload['author'], api.payload['contents'])
+        return create_resource(api.payload['author'], api.payload['contents'], api.payload['messageId'])

--- a/app/main/resources/resources_service.py
+++ b/app/main/resources/resources_service.py
@@ -1,8 +1,7 @@
 import os
 from airtable import Airtable
-import requests
 
-airtable = Airtable('appnfHuWptUFonq1U', 'Resources')
+airtable = Airtable('appnfHuWptUFonq1U', os.environ.get('RESOURCE_TABLE'))
 
 def get_all_resources():
     """
@@ -20,12 +19,17 @@ def get_all_resources():
     
     return result, 200
 
-def create_resource(author, resource_contents):
+def create_resource(author, resource_contents, message_id):
     """
     Creates a new SSE resource and inserts it into the Airtable database given an anthor and 
     the contents of the resource
     """
-    result = airtable.insert({'Author': author, 'ResourceContents': resource_contents})
+    match = airtable.match('SlackMessageId', message_id)
 
-    return {'author': result['fields']['Author'], 'contents': result['fields']['ResourceContents']}, 200
+    if not match:    
+        result = airtable.insert({'Author': author, 'ResourceContents': resource_contents, 'SlackMessageId': message_id})
+
+        return {'author': result['fields']['Author'], 'contents': result['fields']['ResourceContents']}, 200
+    
+    return {'error': 'Message has already been saved as a resource.'}, 400
 

--- a/app/main/resources/resources_service.py
+++ b/app/main/resources/resources_service.py
@@ -21,8 +21,8 @@ def get_all_resources():
 
 def create_resource(author, resource_contents, message_id):
     """
-    Creates a new SSE resource and inserts it into the Airtable database given an anthor and 
-    the contents of the resource
+    Creates a new SSE resource and inserts it into the Airtable database given an author, 
+    the contents of the resource, and the message slack id we're saving as a resource
     """
     match = airtable.match('SlackMessageId', message_id)
 

--- a/app/test/resources_service_test.py
+++ b/app/test/resources_service_test.py
@@ -16,7 +16,7 @@ class ResourcesServiceTest(unittest.TestCase):
         }, {
             'fields': {'ResourceContents': 'contents'}
         }, {
-            'fields': {'Author': 'andy', 'ResourceContents': 'contents'}
+            'fields': {'Id': 1, 'Author': 'andy', 'ResourceContents': 'contents', 'SlackMessageId': "messageId"}
         }]
 
         airtable_mock.get_all.return_value = airtable_response
@@ -33,23 +33,45 @@ class ResourcesServiceTest(unittest.TestCase):
         self.assertEqual('contents', result['resources'][0]['contents'])
     
     @patch('app.main.resources.resources_service.airtable')
-    def test_create_resource(self, airtable_mock):
+    def test_create_resource_success(self, airtable_mock):
         """
-        Basic test case for the get_all_resources method in the resource_service
+        Basic test case for the create_resource method in the resource_service
         """
         # Arrange
+        airtable_mock.match.return_value = {}
         airtable_mock.insert.return_value = {
-            'fields': {'Author': 'andy', 'ResourceContents': 'contents'}
+            'fields': {'Author': 'andy', 'ResourceContents': 'contents', 'SlackMessageId': 'id'}
         }
 
         # Act
-        result = create_resource('andy', 'contents')[0]
+        result = create_resource('andy', 'contents', 'id')
 
         # Assert
-        airtable_mock.insert.assert_called_once_with({'Author': 'andy', 'ResourceContents': 'contents'})
+        airtable_mock.insert.assert_called_once_with({'Author': 'andy', 'ResourceContents': 'contents', 'SlackMessageId': 'id'})
 
-        self.assertEqual('andy', result['author'])
-        self.assertEqual('contents', result['contents'])
+        self.assertEqual('andy', result[0]['author'])
+        self.assertEqual('contents', result[0]['contents'])
+        self.assertEqual(200, result[1])
+    
+    @patch('app.main.resources.resources_service.airtable')
+    def test_create_resource_duplicate_message(self, airtable_mock):
+        """
+        Test Case for the create_resource where the message being saved already exists in Airtable
+        """
+        # Arrange
+        airtable_mock.match.return_value = {'fields': {'SlackMessageId': 'id'}}
+        airtable_mock.insert.return_value = {
+            'fields': {'Author': 'andy', 'ResourceContents': 'contents', 'SlackMessageId': 'id'}
+        }
+
+        # Act
+        result = create_resource('andy', 'contents', 'id')
+
+        # Assert
+        self.assertFalse(airtable_mock.insert.called)
+
+        self.assertEqual('Message has already been saved as a resource.', result[0]['error'])
+        self.assertEqual(400, result[1])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR finalizes the initial functionality of the SSE resources feature without regarding security yet which we need to talk about. Handling was added to prevent duplicate messages from being saved as resources, which will prevent people from spamming the archive resource command in the Historian. 

Also, the README was updated with SSE Resource information. I reorganized the README to include separate setup instruction sections for the Points and Resources namespace. Finally I added an additional environment variable to differentiate between the prod/staging Resource tables