### PR TITLE
Added authorization based on an API key

### DIFF
--- a/app/main/auth/authorize.py
+++ b/app/main/auth/authorize.py
@@ -1,0 +1,20 @@
+from functools import wraps
+from flask import request
+import os
+
+def authorize(f):
+    @wraps(f)
+    def decorated_function(*args, **kws):
+        if 'Authorization' not in request.headers:
+            return {'error': 'Unauthorized'}, 401
+        
+        token = str.replace(request.headers['Authorization'], 'Bearer ', '')
+
+        if token != os.getenv('SSE_API_KEY'):
+            return {'error': 'Unauthorized'}, 401
+        
+        return f(*args, **kws)
+    decorated_function.__doc__ = f.__doc__
+    decorated_function.__name__ = f.__name__
+    return decorated_function
+        

--- a/app/main/controllers/resources_controller.py
+++ b/app/main/controllers/resources_controller.py
@@ -1,6 +1,7 @@
 from flask_restplus import Resource
 from ..resources.resources_service import get_all_resources, create_resource
 from ..resources.resources_dto import ResourcesDto
+from ..auth.authorize import authorize
 
 api = ResourcesDto.api
 _resources = ResourcesDto.resources
@@ -15,5 +16,6 @@ class Resources(Resource):
     
     @api.doc('creates a new SSE resource')
     @api.expect(_resource)
+    @authorize
     def post(self):
         return create_resource(api.payload['author'], api.payload['contents'], api.payload['messageId'])


### PR DESCRIPTION
Added a decorator that can be added to certain endpoints to indicate an API key is needed in the request. So, for those endpoints a bearer token needs to be passed matching an API key stored in the environment.